### PR TITLE
Should ignore main.swift only in the Sources folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 Packages
 .build
-main.swift
+Sources/main.swift
 Public
 Resources


### PR DESCRIPTION
Feels a bit more clean.