### PR TITLE
Update Router.swift

### DIFF
--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -85,8 +85,8 @@ class Router {
         if let _ = node.nodes[pathToken] {
             return findHandler(&node.nodes[pathToken]!, params: &params, generator: &generator)
         }
-        if let _ = node.nodes["*"] {
-            return findHandler(&node.nodes["*"]!, params: &params, generator: &generator)
+        if let starNode = node.nodes["*"] {
+            return starNode.handler
         }
         return nil
     }


### PR DESCRIPTION
Fixed the * logic, it should return the handler directly after the star notation is detected

Thanks to your work, it's very awesome with the simplicity of the swift server, i just discover the star notation has some strange behaviours during my demo, and I just make some changes, you can check with it and give me feedback if i misunderstood your design, thanks.

Here are the demo codes from me:
`Route.get("ken/*") { request in`
`    let response: [String: Any] = [`
`        "request.path": request.path,`
`        "request.data": request.data,`
`        "request.parameters": request.parameters,`
`        "KenKen": "hihi ken/*"`
`    ]`
`    return response   `
`}`
``
``
`let server = Server()`
`server.run(port: 8080)`

However when i access http://localhost:8080/ken/a/a/a, "Page not found" will be shown