### PR TITLE
fix query values in params

### DIFF
--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -27,7 +27,7 @@ public class Server: SocketServer {
                         if requestPaths.count > index {
                             var trimPath = path
                             trimPath.removeAtIndex(path.startIndex)
-                            request.parameters[trimPath] = requestPaths[index]
+                            request.parameters[trimPath] = requestPaths[index].split("?")[0]
                         }
                     }
                 }


### PR DESCRIPTION
if you have an url like
```
http://localhost:8080/data/5?query=test&hello=now
```

the value for request.parameters was

```
5?query=test&hello=now
```

this fix, force this value avoiding any query string to be appended.

Now the value is only

```
5
```