### PR TITLE
Decode percent encoded strings in parameters

### DIFF
--- a/Sources/NodeRouter.swift
+++ b/Sources/NodeRouter.swift
@@ -122,7 +122,7 @@ class NodeRouter: RouterDriver {
             var key = variableNode.key
             key.removeAtIndex(key.startIndex)
             
-            request.parameters[key] = path
+            request.parameters[key] = path.stringByRemovingPercentEncoding
             return self.search(variableNode.node, paths: paths, request: request)
         } else if let pathNode = node.nodes[path] {
             return self.search(pathNode, paths: paths, request: request)

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -49,11 +49,15 @@ class RouterTests: XCTestCase {
         let percentEncodedString = "testing%20parameter%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
         let decodedString = "testing parameter!#$&'()*+,/:;=?@[]"
         
+        var handlerRan = false
+        
         router.register(hostname: nil, method: .Get, path: "test/:string") { request in
             
             let testParameter = request.parameters["string"]
             
             XCTAssert(testParameter == decodedString, "URL parameter was not decoded properly")
+            
+            handlerRan = true
             
             return Response(status: .OK, data: [], contentType: .None)
         }
@@ -62,6 +66,8 @@ class RouterTests: XCTestCase {
         let handler = router.route(request)
         
         handler?(request)
+        
+        XCTAssert(handlerRan, "The handler did not run, and the parameter test also did not run")
     }
     
 }

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -43,4 +43,25 @@ class RouterTests: XCTestCase {
         }
     }
     
+    func testURLParameterDecoding() {
+        let router = NodeRouter()
+        
+        let percentEncodedString = "testing%20parameter%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
+        let decodedString = percentEncodedString.stringByRemovingPercentEncoding
+        
+        router.register(hostname: nil, method: .Get, path: "test/:string") { request in
+            
+            let testParameter = request.parameters["string"]
+            
+            XCTAssert(testParameter == decodedString, "URL parameter was not decoded properly")
+            
+            return Response(status: .OK, data: [], contentType: .None)
+        }
+        
+        let request = Request(method: .Get, path: "test/\(percentEncodedString)", address: nil, headers: [:], body: [])
+        let handler = router.route(request)
+        
+        handler?(request)
+    }
+    
 }

--- a/Tests/RouterTests.swift
+++ b/Tests/RouterTests.swift
@@ -47,7 +47,7 @@ class RouterTests: XCTestCase {
         let router = NodeRouter()
         
         let percentEncodedString = "testing%20parameter%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D"
-        let decodedString = percentEncodedString.stringByRemovingPercentEncoding
+        let decodedString = "testing parameter!#$&'()*+,/:;=?@[]"
         
         router.register(hostname: nil, method: .Get, path: "test/:string") { request in
             


### PR DESCRIPTION
This is a simple PR that decodes strings using `stringByRemovingPercentEncoding` before inserting them into parameters. Almost every web server does this automatically. 

I was unsure of what to do with regards to tests, as I didn't see existing tests for the parameters. If I could get feedback on that, I would love to write tests if needed. 